### PR TITLE
add log-in wizard

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -10,6 +10,7 @@ de:
     pricing: "Preis"
     contact: "Kontakt"
     blog: "Blog"
+    sign_in: "Einloggen"
 
   announcement:
     heading_html: "Join us for our Launch Event on December 11th!"
@@ -68,8 +69,13 @@ de:
   copyright: "Copyright Defacto 2014, All rights reserved"
   credit: "Wird dir stolz präsentiert von"
 
+  sign_in:
+    domain: Gebe die LearningSpaces Domain von deinem Team ein
+    continue: Weiter
+    create_tenant: Du willst LearningSpaces für dein Team haben? Klicke hier.
+
   trial:
-    request: Jetzt kostenlos testen
+    request: Jetzt kostenlos LearningSpaces testen
     signup:
       name: Name
       organization: Organisation
@@ -78,9 +84,9 @@ de:
       tagline: Teste LearningSpaces für 30 Tage! Fülle einfach deine Daten unten ein.
       footer: Was ist LearningSpaces?
     thanks:
-      headline: "Awesome, thanks for signing up!"
-      tagline: We'll contact you shortly.
-      back: Back to the homepage
+      headline: "Awesome, danke für's registrieren!"
+      tagline: Wir melden uns bald bei dir.
+      back: Zurück zur homepage
 
   # Used in JavaScript
   javascript:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -10,6 +10,7 @@ en:
     pricing: "Pricing"
     contact: "Contact"
     blog: "Blog"
+    sign_in: "Log In"
 
   announcement:
     heading_html: "Join us for our Launch Event on December 11th!"
@@ -68,8 +69,13 @@ en:
   copyright: "Copyright Defacto 2014, All rights reserved"
   credit: "Proudly brought to you by"
 
+  sign_in:
+    domain: Enter your team's LearningSpaces domain
+    continue: Continue
+    create_tenant: Trying to set up LearningSpaces for your team? Click here.
+
   trial:
-    request: Request Trial
+    request: Try LearningSpaces Now - it's Free!
     signup:
       name: Name
       organization: Organization

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -10,6 +10,7 @@ nl:
     pricing: "Pricing"
     contact: "Contact"
     blog: "Blog"
+    sign_in: "Inloggen"
 
   announcement:
     heading_html: "Launchparty op 11 december!"
@@ -68,8 +69,13 @@ nl:
   copyright: "Copyright Defacto 2014, All rights reserved"
   credit: "Proudly brought to you by"
 
+  sign_in:
+    domain: Vul het LearningSpaces domein van je team in
+    continue: Verder
+    create_tenant: Probeer LearningSpaces met je team. Klik hier!
+
   trial:
-    request: Vraag een trial aan
+    request: Probeer LearningSpaces nu - Gratis!
     signup:
       name: Naam
       organization: Organisatie

--- a/source/javascripts/landing.js
+++ b/source/javascripts/landing.js
@@ -1,4 +1,3 @@
-//= require jquery
 //= require jquery.scrollTo
 //= require typed
 //= require locales

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <%= favicon_tag            "favicon.ico" %>
     <%= stylesheet_link_tag    "landing" %>
-    <%= javascript_include_tag "landing" %>
+    <%= javascript_include_tag "https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js", "landing" %>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.3, minimal-ui">
     <meta name="description" content="<%= t("landing.head_description") %>">

--- a/source/layouts/panel.erb
+++ b/source/layouts/panel.erb
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <%= favicon_tag            "favicon.ico" %>
     <%= stylesheet_link_tag    "landing" %>
+    <%= javascript_include_tag "https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js" %>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.3, minimal-ui">
     <meta name="description" content="<%= t("landing.head_description") %>">

--- a/source/localizable/_header.erb
+++ b/source/localizable/_header.erb
@@ -1,18 +1,21 @@
 <header id="header">
   <div class="header-wrapper">
     <div class="logo">
-      <%= image_tag 'logo-cube-white.svg', :class => 'logo-cube' %>
-      <%= image_tag 'logo-text-white.svg', :class => 'logo-text', :alt => t("application_name") %>
+        <a href="/">
+          <%= image_tag 'logo-cube-white.svg', :class => 'logo-cube' %>
+          <%= image_tag 'logo-text-white.svg', :class => 'logo-text', :alt => t("application_name") %>
+        </a>
     </div>
     <button type="button" class="button button-white header-menu-button" id="mobile-menu-toggle">
       <span class="bar"></span><span class="bar"></span><span class="bar"></span>
     </button>
     <nav class="nav" role="navigation">
       <ul id="header-menu">
-        <li><a href="javascript:void(0)" data-scrollto="#features" class="link"><%= t("menu.about") %></a></li>
-        <li><a href="javascript:void(0)" data-scrollto="#pricing" class="link"><%= t("menu.pricing") %></a></li>
-        <li><a href="javascript:void(0)" data-scrollto="#contact" class="link"><%= t("menu.contact") %></a></li>
+        <li><a href="/#features" data-scrollto="#features" class="link"><%= t("menu.about") %></a></li>
+        <li><a href="/#pricing" data-scrollto="#pricing" class="link"><%= t("menu.pricing") %></a></li>
+        <li><a href="/#contact" data-scrollto="#contact" class="link"><%= t("menu.contact") %></a></li>
         <li><a href="http://blog.learningspaces.io" class="link"><%= t("menu.blog") %></a></li>
+        <li><%= link_to t("menu.sign_in"), "sign-in", class: "link" %></li>
       </ul>
     </nav>
   </div>

--- a/source/localizable/sign-in/index.html.erb
+++ b/source/localizable/sign-in/index.html.erb
@@ -1,0 +1,40 @@
+---
+layout: panel
+title: LearningSpaces Log In
+---
+
+<%= partial "header" %>
+
+
+<div class="panel-inner">
+  <div class="container">
+    <h1>Log In</h1>
+    <p><%= t("sign_in.domain") %>:</p>
+
+    <div class="input-group">
+      <input type="text" name="subdomain" id="subdomain" value="" placeholder="domain">
+      <span id="tld" class="input-addon">.learningspaces.io</span>
+    </div>
+
+    <button class="button button-green" id="continue"><%= t("sign_in.continue") %></button>
+  <div class="footer">
+    <%= link_to t("sign_in.create_tenant"), "/trial" %>
+  </div>
+</div>
+
+
+<script>
+  var tld = window.location.hostname.split('.').pop();
+
+  $(function(){
+    $('#tld').text(".learningspaces." + tld);
+    var onClickHandler = function () {
+      var subdomain = $('#subdomain').val();
+      var url = 'https://' + subdomain + '.learningspaces.' + tld;
+      window.location = url;
+    }
+    $('#continue').on('click', onClickHandler);
+  });
+
+
+</script>

--- a/source/localizable/trial/index.html.erb
+++ b/source/localizable/trial/index.html.erb
@@ -3,6 +3,8 @@ layout: panel
 title: LearningSpaces Trial Signup
 ---
 
+<%= partial "header" %>
+
 <div class="panel-inner">
   <div class="container">
     <div class="logo">

--- a/source/stylesheets/_panel.scss
+++ b/source/stylesheets/_panel.scss
@@ -5,6 +5,10 @@ body.panel {
   min-height: 100%;
   text-align: center;
 
+  #header {
+    @include background-pattern($color-primary);
+  }
+
   .panel-inner {
     @include display(flex);
     @include flex-direction(column);

--- a/source/stylesheets/_sign-in.scss
+++ b/source/stylesheets/_sign-in.scss
@@ -1,0 +1,35 @@
+body.sign-in {
+  #header {
+    @include background-pattern($color-primary);
+  }
+
+  h1 {
+    margin-top: 0;
+  }
+
+  .input-group {
+    display: table;
+    margin-bottom: 1em;
+    width: 100%;
+
+    input {
+      display: table-cell;
+      margin-bottom: 0;
+      text-align: right;
+    }
+
+    .input-addon {
+      background-color: #eee;
+      border: 1px solid #ccc;
+      border-left: none;
+      color: #555;
+      display: table-cell;
+      font-size: .8em;
+      text-align: center;
+    }
+  }
+
+  .button-green {
+    width: 100%;
+  }
+}

--- a/source/stylesheets/base/_buttons.scss
+++ b/source/stylesheets/base/_buttons.scss
@@ -55,6 +55,7 @@ input[type="reset"] {
 .button-white {
   border-color: $light-gray;
   color: $light-gray !important;
+  white-space: normal;
 
   &:hover,
   &:active {

--- a/source/stylesheets/landing.scss
+++ b/source/stylesheets/landing.scss
@@ -20,3 +20,5 @@
 @import "pricing";
 @import "contact";
 @import "footer";
+@import "sign-in";
+


### PR DESCRIPTION
This PR adds a log-in option to the landing-page menu: 

![screen shot 2015-01-31 at 14 18 39](https://cloud.githubusercontent.com/assets/4135610/5988159/299c5a06-a954-11e4-9858-6d7d1551b09b.png)

Users trying to log in will be prompted for their team's LearningSpaces domain. We user javascript to determine which TLD the user is on (.io/.nl/.de) and bring them to the right login page. (We'll look into a way to check if the provided tenant exists or to look up a user's tenant).

![screen shot 2015-01-31 at 14 18 45](https://cloud.githubusercontent.com/assets/4135610/5988161/4363efd0-a954-11e4-99b0-2a58bdf9a1c4.png)

Also added de top bar to the trial view: 

![screen shot 2015-01-31 at 14 19 04](https://cloud.githubusercontent.com/assets/4135610/5988165/68b8272e-a954-11e4-991e-a6ed334982fb.png)

