### PR TITLE
[ready] meta tags improvements

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
-    <title><%= t("#{current_page.data.i18n_page_name}.head_title") %></title>
     <meta charset="utf-8">
+    <title><%= t("#{current_page.data.i18n_page_name}.head_title") %></title>
     <%= favicon_tag            "favicon.ico" %>
     <%= stylesheet_link_tag    "landing" %>
     <%= javascript_include_tag "https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js", "landing" %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <title><%= t("#{current_page.data.i18n_page_name}.head_title") %></title>
     <%= favicon_tag            "favicon.ico" %>
     <%= stylesheet_link_tag    "landing" %>
     <%= javascript_include_tag "https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js", "landing" %>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.3, minimal-ui">
     <meta name="description" content="<%= t("#{current_page.data.i18n_page_name}.head_description") %>">
     <meta name="keywords" content="<%= t("#{current_page.data.i18n_page_name}.head_keywords") %>">


### PR DESCRIPTION
- Charset should be defined before the title tag, to render the title in the correct set
- Moved X-UA-Compatible tag to top, possibly avoiding the current "X-UA-Compatible meta tag ignored because document mode is already finalized"
- Chrome frame is no longer supported and shouldn't be requested anymore