### PR TITLE
[READY] add terms of use to landingpage footer

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -81,8 +81,10 @@ de:
 
   contact:
     info_html: "Für mehr Informationen melden Sie sich bei uns."
-  terms: "AGB"
-  terms_file: "files/Leveringsovereenkomst_LearningSpaces v1.0.pdf"
+  terms_of_service: "Lieferbedingungen"
+  terms_of_service_file: "files/Leveringsovereenkomst_LearningSpaces v1.0.pdf"
+  terms_of_use: "Nutzungsbedingungen"
+  terms_of_use_file: "files/Gebruiksvoorwaarden_LearningSpaces v1.0.pdf"
   jobs: "Jobs"
 
   login:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -81,8 +81,10 @@ en:
       cta_sub: No credit card required.
   contact:
     info_html: "Please contact us for more information."
-  terms: "Terms and conditions"
-  terms_file: "files/Leveringsovereenkomst_LearningSpaces v1.0.pdf"
+  terms_of_service: "Terms"
+  terms_of_service_file: "files/Leveringsovereenkomst_LearningSpaces v1.0.pdf"
+  terms_of_use: "Conditions"
+  terms_of_use_file: "files/Gebruiksvoorwaarden_LearningSpaces v1.0.pdf"
   jobs: "Jobs"
 
   login:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -81,8 +81,10 @@ nl:
   contact:
     info_html: "Neem contact met ons op voor meer informatie."
   copyright: "Copyright Defacto 2014, All rights reserved"
-  terms: "Leveringsvoorwaarden"
-  terms_file: "files/Leveringsovereenkomst_LearningSpaces v1.0.pdf"
+  terms_of_service: "Leveringsvoorwaarden"
+  terms_of_service_file: "files/Leveringsovereenkomst_LearningSpaces v1.0.pdf"
+  terms_of_use: "Gebruiksvoorwaarden"
+  terms_of_use_file: "files/Gebruiksvoorwaarden_LearningSpaces v1.0.pdf"
   jobs: "Vacatures"
 
   login:

--- a/source/localizable/_footer.html.erb
+++ b/source/localizable/_footer.html.erb
@@ -4,7 +4,8 @@
       <li class="copyright">
         <a href="http://www.defacto.nl" target="_blank">&copy; <%= Time.now.year %> Defacto</a>
       </li>
-      <li class="terms"><%= link_to t("terms"), asset_url(t("terms_file")) %></li>
+      <li class="terms"><%= link_to t("terms_of_service"), asset_url(t("terms_of_service_file")) %></li>
+      <li class="terms"><%= link_to t("terms_of_use"), asset_url(t("terms_of_use_file")) %></li>
       <li class="jobs"><a href="https://www.hellohired.com/learningspaces"><%= t("jobs") %></a></li>
     </ul>
   </div>


### PR DESCRIPTION
the link to it was missing

also don't we need translations?