### PR TITLE
[READY] add public to ga autolinker

### DIFF
--- a/source/_google_analytics.erb
+++ b/source/_google_analytics.erb
@@ -9,6 +9,7 @@
     ga('linker:autoLink', ['www.learningspaces.io', 'blog.learningspaces.io',
       'www.learningspaces.nl', 'blog.learningspaces.nl',
       'www.learningspaces.de', 'blog.learningspaces.de',
-      'www.learningspac.es', 'blog.learningspac.es']);
+      'www.learningspac.es', 'blog.learningspac.es',
+      'public.learningspaces.io', 'public.learningspaces.nl', 'public.learningspaces.de']);
     ga('send', 'pageview');
   </script>


### PR DESCRIPTION
Every (trial) conversion now gets attributed to one of the three landing pages. Let's see if autolink makes sure the conversion gets attributed to the right channel. 

Fixes #110 