### PR TITLE
Fix mobile nav scrolling

### DIFF
--- a/source/stylesheets/components/_header.scss
+++ b/source/stylesheets/components/_header.scss
@@ -1,6 +1,9 @@
 .mobile-nav-open {
   // Disable scrolling
-  overflow: hidden;
+  @include media($large-down) {
+    overflow: hidden;
+    position: fixed;
+  }
 }
 
 .header {


### PR DESCRIPTION
On Chrome for Mobile the mobile nav zoomed in because of scrolling. Not anymore. 

Fix #147